### PR TITLE
Add examples for Char and Pair for invalid inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 skunk/rust/skunk/target
+*.skunk_examples

--- a/skunk/rust/skunk/examples/parser/Char.skunk
+++ b/skunk/rust/skunk/examples/parser/Char.skunk
@@ -1,0 +1,26 @@
+uses UnsignedInt;
+uses Spaces;
+
+type Error = Int;
+
+module Char<char: Char> {
+  input: reads (String, Int);
+  output: writes (String, Int);
+  error: writes Error;
+
+  input.onChange: {
+    if input.0[input.1] == char {
+      output <- (input.0, input.1 + 1);
+    }
+    error <- 1;
+  }
+
+  examples {
+    char: 'a', !input: ("aa", 0) -> output: ("aa", 1);
+    char: 'a', !input: ("ab", 0) -> output: ("ab", 1);
+    char: 'b', !input: ("ab", 1) -> output: ("ab", 2);
+    char: 'b', !input: ("aa", 0) -> error: 1;
+    char: 'a', !input: ("", 0) -> error: 1;
+    char: 'a', !input: ("a", 1) -> error: 1;
+  }
+}

--- a/skunk/rust/skunk/examples/parser/Pair.skunk
+++ b/skunk/rust/skunk/examples/parser/Pair.skunk
@@ -1,24 +1,8 @@
 uses UnsignedInt;
 uses Spaces;
+uses Char;
 
 type Error = Int;
-
-module Char<char: Char> {
-  input: reads (String, Int);
-  output: writes (String, Int);
-  error: writes Error;
-
-  input.onChange: {
-    if input.0[input.1] == char {
-      output <- (input.0, input.1 + 1);
-    }
-    error <- 1;
-  }
-
-  examples {
-    char: 'a', !input: ("aa", 0) -> output: ("aa", 1);
-  }
-}
 
 module Pair {
   input: reads (String, Int);
@@ -30,11 +14,14 @@ module Pair {
   ($a, $b) -> result;
 
   examples {
+    !input: ("", 0) -> result: (3, 4);
     !input: ("3, 4", 0) -> result: (3, 4);
     !input: ("3,   4", 0) -> result: (3, 4);
     !input: ("3, hat", 0) -> error: 1;
     !input: ("3. 4", 0) -> error: 1;
     !input: ("3.. 4", 0) -> error: 1;
     !input: ("3", 0) -> error: 1;
+    !input: ("", 0) -> error: 1;
+    !input: ("3, 4", 1) -> error: 1;
   }
 }


### PR DESCRIPTION
- Covers:
  - empty inputs
  - 'bad' starting indexes
- Also adds skunk_examples to .gitignore